### PR TITLE
Added configuration for Black, Flake8 and pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.6
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,21 @@
+---
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
+  - repo: https://github.com/ambv/black
+    rev: 19.3b0
     hooks:
-    - id: black
-      language_version: python3.6
--   repo: https://github.com/pre-commit/pre-commit-hooks
+      - id: black
+        name: Black
+        language_version: python3.6
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
-    - id: flake8
+      - id: end-of-file-fixer
+      - id: debug-statements
+      - id: check-merge-conflict
+      - id: requirements-txt-fixer
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.16
+    hooks:
+      - id: isort
+        name: Sort imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 algorithmia>=1.0.0,<2.0
 six
+pre-commit


### PR DESCRIPTION
To use these configuration commands, use the following commands:
```
> pip install pre-commit # To install pre-commit itself
> pre-commit install     # To install git hooks in your .git/ directory.
```

This only needs to be done once after cloning this repository.
Henceforth, for any python source files in staging, Black and Flake8
will automatically run in the pre-commit stage.